### PR TITLE
Fix TX PV input link in netStat

### DIFF
--- a/statApp/Db/netStat.substitutions
+++ b/statApp/Db/netStat.substitutions
@@ -26,7 +26,7 @@ file "tblGetRateI64.template" {
  ADEL="10", ASLO="0.0009765625", EGU="KB/s"}
 {NAME="RX:M", INP="netstat|/proc\$(INST)/net/netstat|IpExt:InMcastOctets",
  ADEL="10", ASLO="0.0009765625", EGU="KB/s"}
-{NAME="TX", INP="netstat|/proc\$(INST)/net/netstat|IpExt:OutBcastOctets",
+{NAME="TX", INP="netstat|/proc\$(INST)/net/netstat|IpExt:OutOctets",
  ADEL="10", ASLO="0.0009765625", EGU="KB/s"}
 {NAME="TX:B", INP="netstat|/proc\$(INST)/net/netstat|IpExt:OutBcastOctets",
  ADEL="10", ASLO="0.0009765625", EGU="KB/s"}


### PR DESCRIPTION
This is really nice module!

While having claude help generate a screen using these linStat PVs, it reported a possible copy/paste issue with the TX PV input link. And it looks right to my human eyes