### PR TITLE
Fix TOOLCHAIN generation for cross builds and exampleApp on GCC 8

### DIFF
--- a/configure/Makefile
+++ b/configure/Makefile
@@ -12,4 +12,4 @@ TARGETS += TOOLCHAIN
 include $(TOP)/configure/RULES
 
 TOOLCHAIN: toolchain.cpp
-	$(CXX) -E $< | grep '^LINSTAT_' > $@
+	$(CCC) -E $< | grep '^LINSTAT_' > $@

--- a/exampleApp/src/Makefile
+++ b/exampleApp/src/Makefile
@@ -1,6 +1,9 @@
 TOP=../..
 
 include $(TOP)/configure/CONFIG
+ifdef T_A
+include $(TOP)/configure/O.$(T_A)/TOOLCHAIN
+endif
 #----------------------------------------
 #  ADD MACRO DEFINITIONS AFTER THIS LINE
 #=============================
@@ -32,6 +35,11 @@ endif
 endif
 
 linStatDemo_LIBS += $(EPICS_BASE_IOC_LIBS)
+
+ifeq (YES,$(LINSTAT_NEED_STDCXXFS))
+# see configure/toolchain.cpp
+PROD_SYS_LIBS += stdc++fs
+endif
 
 #===========================
 


### PR DESCRIPTION
EPICS has the strange `CCC` variable instead of `CXX`. I was getting linker errors using GCC 8.3.0 for a cross target because it was checking the libstdc++ version from my host system's compiler.

Also links the exampleApp against libstdc++fs, since that was also generating linker errors. Uses the same snippets that `statApp/src/Makefile` uses.