### PR TITLE
remove use of std::filesystem

### DIFF
--- a/configure/toolchain.cpp
+++ b/configure/toolchain.cpp
@@ -8,14 +8,3 @@
 #include <algorithm>
 
 LINSTAT_HAVE_TOOLCHAIN = YES
-
-#ifdef _COMMENT_
-/* libstdc++ circa GCC 8.x includes preliminary c++17 support, with some quirks.
- * Specifically, std::filesystem support is placed in a seperate library libstdc++fs.a
- *
- * https://gcc.gnu.org/onlinedocs/libstdc++/manual/status.html#status.iso.2017
- */
-#endif
-#if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE==8
-LINSTAT_NEED_STDCXXFS = YES
-#endif

--- a/exampleApp/src/Makefile
+++ b/exampleApp/src/Makefile
@@ -36,11 +36,6 @@ endif
 
 linStatDemo_LIBS += $(EPICS_BASE_IOC_LIBS)
 
-ifeq (YES,$(LINSTAT_NEED_STDCXXFS))
-# see configure/toolchain.cpp
-PROD_SYS_LIBS += stdc++fs
-endif
-
 #===========================
 
 include $(TOP)/configure/RULES

--- a/statApp/src/Makefile
+++ b/statApp/src/Makefile
@@ -50,11 +50,6 @@ LIB_SRCS_DEFAULT += dummy.c
 
 LIB_LIBS += $(EPICS_BASE_IOC_LIBS)
 
-ifeq (YES,$(LINSTAT_NEED_STDCXXFS))
-# see configure/toolchain.cpp
-LIB_SYS_LIBS += stdc++fs
-endif
-
 #===========================
 
 include $(TOP)/configure/RULES

--- a/statApp/src/linStat.h
+++ b/statApp/src/linStat.h
@@ -15,7 +15,6 @@
 #include <sstream>
 #include <functional>
 #include <variant>
-#include <filesystem>
 
 #include <stdint.h>
 
@@ -127,17 +126,25 @@ void addStatTableFactory(const std::string& name,
 
 // utility
 bool starts_with(const std::string& inp, const char *prefix);
-bool read_file(const std::filesystem::path& fname, std::string& out);
+bool read_file(const std::string& fname, std::string& out);
 
 struct ReadDir final {
+    const std::string dirname;
     DIR* const dirFD;
-    struct dirent *ent;
-    ReadDir(const char *dir);
-    ReadDir(const std::string& dir) :ReadDir(dir.c_str()) {}
+    struct dirent *ent = nullptr;
+    ReadDir(const std::string& dir);
     ~ReadDir();
-    bool next();
+    bool next() noexcept;
 
-    const struct dirent* operator->() const { return ent; }
+    constexpr struct dirent* operator->() const noexcept { return ent; }
+    constexpr
+    explicit operator bool() const noexcept { return ent; }
+    constexpr
+    bool is_directory() const noexcept { return ent && ent->d_type==DT_DIR; }
+    std::string filename() const {
+        return ent ? ent->d_name : "";
+    }
+    std::string path() const;
 };
 
 } // namespace linStat

--- a/statApp/src/lsutils.cpp
+++ b/statApp/src/lsutils.cpp
@@ -4,10 +4,11 @@
 
 #include <string.h>
 
+#include <sys/stat.h>
+
 #include "linStat.h"
 
 namespace linStat {
-namespace fs = std::filesystem;
 
 bool starts_with(const std::string& inp, const char *prefix)
 {
@@ -17,7 +18,7 @@ bool starts_with(const std::string& inp, const char *prefix)
     return memcmp(inp.c_str(), prefix, pl)==0;
 }
 
-bool read_file(const fs::path& fname, std::string& out) {
+bool read_file(const std::string &fname, std::string& out) {
     std::ifstream strm(fname);
     if(!strm.is_open())
         return false;
@@ -25,8 +26,16 @@ bool read_file(const fs::path& fname, std::string& out) {
     return !!(strm>>out);
 }
 
-ReadDir::ReadDir(const char *dir)
-    :dirFD(opendir(dir))
+ReadDir::ReadDir(const std::string& dir)
+    :dirname([&]() -> std::string { // ensure trailing '/'
+        auto dn(dir);
+        if(dn.empty())
+            dn = "./";
+        else if(dn.back()!='/')
+            dn.push_back('/');
+        return dn;
+    }())
+    ,dirFD(opendir(dirname.c_str()))
 {
     if(!dirFD) {
         auto err = errno;
@@ -38,10 +47,26 @@ ReadDir::~ReadDir()
     (void)closedir(dirFD);
 }
 
-bool ReadDir::next()
+bool ReadDir::next() noexcept
 {
     ent = readdir(dirFD);
+    if(ent && ent->d_type==DT_LNK) {
+        // readdir() does not follow symlinks, fstatat does
+        struct stat st{};
+        if(fstatat(dirfd(dirFD), ent->d_name, &st, 0)==0) {
+            switch(st.st_mode & S_IFMT) {
+            case S_IFDIR: ent->d_type = DT_DIR; break;
+            case S_IFREG: ent->d_type = DT_REG; break;
+            default: break; // unnecessary so far
+            }
+        }
+    }
     return ent!=NULL;
+}
+
+std::string ReadDir::path() const
+{
+    return dirname + filename();
 }
 
 } // namespace linState

--- a/statApp/src/tblHwmon.cpp
+++ b/statApp/src/tblHwmon.cpp
@@ -14,7 +14,6 @@
  * https://www.kernel.org/doc/Documentation/hwmon/sysfs-interface
  */
 
-#include <filesystem>
 #include <set>
 #include <fstream>
 #include <regex>
@@ -28,13 +27,12 @@
 
 namespace {
 using namespace linStat;
-namespace fs = std::filesystem;
 
 const char * const tblName = "hwmon";
 
 struct HWMonTable : public StatTable {
 
-    const fs::path base;
+    const std::string base;
 
     explicit HWMonTable(const std::string& inst, const Reactor& react)
         :StatTable(tblName, inst, react)
@@ -57,12 +55,13 @@ struct HWMonTable : public StatTable {
         int64_t Fnum = 0, Fturning = 0, Fstuck = 0;
 
         // iterate through hwmon* devices
-        for(const auto& ent : fs::directory_iterator(base)) {
-            if(!ent.is_directory() || !starts_with(ent.path().filename().string(), "hwmon"))
+        ReadDir ent(base);
+        while(ent.next()) {
+            if(!ent.is_directory() || !starts_with(ent.filename(), "hwmon"))
                 continue;
 
             std::string dev;
-            if(!read_file(ent.path() / "name", dev) || dev.empty())
+            if(!read_file(ent.path() + "/name", dev) || dev.empty())
                 continue;
 
             if(devs_seen.find(dev)!=devs_seen.end())
@@ -79,13 +78,14 @@ struct HWMonTable : public StatTable {
             };
             std::map<std::string, Fan> fans;
 
-            for(const auto& sv : fs::directory_iterator(ent.path())) {
+            ReadDir sv(ent.path());
+            while(sv.next()) {
                 // looking for entries of the form: <type><inst#>_<param>
                 static const std::regex expr(R"(^([a-z]+)(\d+)_([a-z]+)$)");
 
                 std::smatch M;
                 {
-                    auto fname(sv.path().filename().string());
+                    auto fname(sv.filename());
                     if(!std::regex_match(fname, M, expr))
                         continue;
                 }


### PR DESCRIPTION
Removes the need for linking the special `libstdc++fs` with GCC 8, which is tedious with static linking.

Thinking again of https://github.com/mdavidsaver/linStat/pull/16#discussion_r3248970428 , I realized that linStat already has a `ReadDir` utlility, which was almost sufficient to replace `fd::directory_iterator`.  The only necessary addition was following symlinks.

@JJL772 Are you interested in testing this change?